### PR TITLE
Fixed np.random.choice 1-dimensional error

### DIFF
--- a/week2_model_based/mdp.py
+++ b/week2_model_based/mdp.py
@@ -90,7 +90,7 @@ class MDP:
     def step(self, action):
         """ take action, return next_state, reward, is_done, empty_info """
         possible_states, probs = zip(*self.get_next_states(self._current_state, action).items())
-        next_state = np.random.choice(possible_states, p=probs)
+        next_state = possible_states[np.random.choice(len(possible_states), p=probs)]
         reward = self.get_reward(self._current_state, action, next_state)
         is_done = self.is_terminal(next_state)
         self._current_state = next_state


### PR DESCRIPTION
Problem with "np.random.choice". It allows only 1-dimensional arrays and does not support list of tuples.

How to reproduce:
```
Python 3.6.8 (default, Dec 24 2018, 19:24:27) 
[GCC 5.4.0 20160609] on linux
>>> import numpy as np
>>> np.__version__
'1.16.1'
>>> np.random.choice([(1, 1), (1, 2), (2, 1)], p=[1.0, 0, 0])
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "mtrand.pyx", line 1121, in mtrand.RandomState.choice
ValueError: 'a' must be 1-dimensional
```